### PR TITLE
Update config.go - fix to allow IPv6 addresses in /etc/resolv.conf

### DIFF
--- a/src/argus/resolv/config.go
+++ b/src/argus/resolv/config.go
@@ -103,7 +103,7 @@ func addSearch(dom string) {
 
 func addServer(ns string) {
 
-	ua, err := net.ResolveUDPAddr("udp", ns+":53")
+	ua, err := net.ResolveUDPAddr("udp", "["+ns+"]:53")
 	if err != nil {
 		diag.Fatal("invalid namserver: %s (%v)", ns, err)
 	}


### PR DESCRIPTION
This is a fix for https://github.com/jaw0/argus5/issues/9